### PR TITLE
Update node-rss.js

### DIFF
--- a/lib/node-rss.js
+++ b/lib/node-rss.js
@@ -67,7 +67,7 @@ exports.getFeedXML = function (feed) {
     var aLink = channel.node('atom:link');
     aLink.attr({ href: feed.feedLink, rel: 'self', type: 'application/rss+xml' });
     var now = new Date();
-    channel.node('lastBuildDate', now.toString());
+    channel.node('lastBuildDate', now.toUTCString());
     
     feed.items.forEach(function (item) {
         var itemNode = channel.node('item');


### PR DESCRIPTION
According to http://validator.w3.org/feed/
This feed does not validate.
line 9, column 58: lastBuildDate must be an RFC-822 date-time: Thu Jan 29 2015 09:43:48 GMT+0000 (UTC)
My proposed change will fix the problem.
