### PR TITLE
Update libxmljs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/ebensing/node-rss"
   },
   "dependencies" : {
-    "libxmljs" : "0.13.0"
+    "libxmljs" : "0.14.x"
   },
   "keywords": [
     "rss"


### PR DESCRIPTION
the current version will not compile on newer versions of clang++ on mac osx (it seems), due to an issue with nan https://github.com/nodejs/nan/pull/235

the newest version of libxmljs updates the nan dependency.

thanks
